### PR TITLE
Added Accelerator for Save As.

### DIFF
--- a/src/main/resources/net/rptools/tokentool/view/TokenTool.fxml
+++ b/src/main/resources/net/rptools/tokentool/view/TokenTool.fxml
@@ -44,7 +44,7 @@
 								<MenuItem fx:id="fileManageOverlaysMenu" onAction="#fileManageOverlaysMenu_onAction" text="%menu.title.file.manage.overlays" />
 								<MenuItem fx:id="fileSaveAsMenu" onAction="#fileSaveAsMenu_onAction" text="%menu.title.file.save.as">
                            <accelerator>
-                              <KeyCodeCombination alt="UP" code="S" control="ANY" meta="UP" shift="ANY" shortcut="UP" />
+                              <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="ANY" shortcut="UP" />
                            </accelerator></MenuItem>
 								<SeparatorMenuItem mnemonicParsing="false" />
 								<MenuItem fx:id="fileExitMenu" onAction="#fileExitMenu_onAction" text="%menu.title.file.exit" />
@@ -56,12 +56,12 @@
 								<SeparatorMenuItem mnemonicParsing="false" />
 								<MenuItem fx:id="editCopyImageMenu" onAction="#editCopyImageMenu_onAction" text="%menu.title.edit.copy.image">
 									<accelerator>
-										<KeyCodeCombination alt="UP" code="C" control="ANY" meta="UP" shift="UP" shortcut="UP" />
+										<KeyCodeCombination alt="UP" code="C" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
 									</accelerator>
 								</MenuItem>
 								<MenuItem fx:id="editPasteImageMenu" onAction="#editPasteImageMenu_onAction" text="%menu.title.edit.paste.image">
 									<accelerator>
-										<KeyCodeCombination alt="UP" code="V" control="ANY" meta="UP" shift="UP" shortcut="UP" />
+										<KeyCodeCombination alt="UP" code="V" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
 									</accelerator>
 								</MenuItem>
 							</items>

--- a/src/main/resources/net/rptools/tokentool/view/TokenTool.fxml
+++ b/src/main/resources/net/rptools/tokentool/view/TokenTool.fxml
@@ -33,7 +33,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="net.rptools.tokentool.controller.TokenTool_Controller">
+<BorderPane xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="net.rptools.tokentool.controller.TokenTool_Controller">
 	<center>
 		<VBox prefHeight="800.0" prefWidth="800.0">
 			<children>
@@ -42,7 +42,10 @@
 						<Menu text="%menu.title.file">
 							<items>
 								<MenuItem fx:id="fileManageOverlaysMenu" onAction="#fileManageOverlaysMenu_onAction" text="%menu.title.file.manage.overlays" />
-								<MenuItem fx:id="fileSaveAsMenu" onAction="#fileSaveAsMenu_onAction" text="%menu.title.file.save.as" />
+								<MenuItem fx:id="fileSaveAsMenu" onAction="#fileSaveAsMenu_onAction" text="%menu.title.file.save.as">
+                           <accelerator>
+                              <KeyCodeCombination alt="UP" code="S" control="ANY" meta="UP" shift="ANY" shortcut="UP" />
+                           </accelerator></MenuItem>
 								<SeparatorMenuItem mnemonicParsing="false" />
 								<MenuItem fx:id="fileExitMenu" onAction="#fileExitMenu_onAction" text="%menu.title.file.exit" />
 							</items>


### PR DESCRIPTION
This is a really tiny change, but the lack of a hotkey to write out an image bothered me when I tried out the javafx port. The JavaFX port is otherwise great. 

It ignores crtl and shift. Shift-S is normal for 'Save As', but there isn't a 'Save' so I made just 'S' map to this as well. Ignoring control is an odd idea to me, but your copy and paste Accelerators do so I though it was best to keep consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/tokentool/11)
<!-- Reviewable:end -->
