### PR TITLE
Update log4j for security fix

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,14 @@
+TokenTool 2.2.2
+=====
+Security fix release for vulnerability in [Apache Log4J library](https://www.cisa.gov/uscert/ncas/current-activity/2021/12/10/apache-releases-log4j-version-2150-address-critical-rce)
+
+Changes
+-----
+* [#254][i254] - Updates Log4J to 2.15.0
+
+[i254]: https://github.com/RPTools/TokenTool/issues/254
+
+
 TokenTool 2.2.1
 =====
 Bug fix release.  Two quick bug fixes related to overlays and save file type.  See below.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,11 +95,9 @@ repositories {
 
 dependencies {
     // Logging
-    annotationProcessor(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.14.1")
-    implementation(group = "org.apache.logging.log4j", name = "log4j-api", version = "2.14.1")
-
-    // Note: log4j-1.2-api(versions 2.12.1+ breaks logging)
-    implementation(group = "org.apache.logging.log4j", name = "log4j-1.2-api", version = "2.14.1")
+    annotationProcessor(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.15.0")
+    implementation(group = "org.apache.logging.log4j", name = "log4j-api", version = "2.15.0")
+    implementation(group = "org.apache.logging.log4j", name = "log4j-1.2-api", version = "2.15.0")
 
     // Bridges v1 to v2 for other code in other libs
     implementation(group = "org.slf4j", name = "slf4j-simple", version = "1.7.31")


### PR DESCRIPTION
Update log4j for security fix.

https://www.cisa.gov/uscert/ncas/current-activity/2021/12/10/apache-releases-log4j-version-2150-address-critical-rce

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/tokentool/254)
<!-- Reviewable:end -->
