### PR TITLE
Add log4j-core to the classpath

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -33,13 +33,13 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: Cache Gradle
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        key: ${{ runner.os }}-gradle-v4-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-v2-
+          ${{ runner.os }}-gradle-v4-
     - name: Build with Gradle
       run: ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,7 @@ repositories {
 dependencies {
     // Logging
     annotationProcessor(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.19.0")
+    implementation(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.19.0")
     implementation(group = "org.apache.logging.log4j", name = "log4j-api", version = "2.19.0")
     implementation(group = "org.apache.logging.log4j", name = "log4j-1.2-api", version = "2.19.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ spotless {
     java {
         licenseHeaderFile("${projectDir}/spotless.license.java")
         targetExclude("**/module-info.java")
-        //googleJavaFormat()
+        googleJavaFormat()
     }
 
     format("misc") {

--- a/src/main/java/net/rptools/tokentool/AppConstants.java
+++ b/src/main/java/net/rptools/tokentool/AppConstants.java
@@ -71,13 +71,14 @@ public class AppConstants {
   public static final File CACHE_DIR = AppSetup.getAppHome("cache");
   public static final ExtensionFilter DEFAULT_EXTENSION_FILTER =
       new ExtensionFilter(DEFAULT_IMAGE_EXTENSION_DESCRIPTION, "*." + DEFAULT_IMAGE_EXTENSION);
-  public static final Set<ExtensionFilter> IMAGE_EXTENSION_FILTER = new HashSet<>(Arrays.asList(
-      new ExtensionFilter("WebP Image", "*.webp"),
-      new ExtensionFilter("PNG Image", "*.png"),
-      new ExtensionFilter("JPEG Image", "*.jpg"),
-      new ExtensionFilter("GIF Image", "*.gif"),
-      new ExtensionFilter("TIFF Image", "*.tif")
-  ));
+  public static final Set<ExtensionFilter> IMAGE_EXTENSION_FILTER =
+      new HashSet<>(
+          Arrays.asList(
+              new ExtensionFilter("WebP Image", "*.webp"),
+              new ExtensionFilter("PNG Image", "*.png"),
+              new ExtensionFilter("JPEG Image", "*.jpg"),
+              new ExtensionFilter("GIF Image", "*.gif"),
+              new ExtensionFilter("TIFF Image", "*.tif")));
 
   public static final double DEFAULT_PORTRAIT_TRANSPARENCY = 1;
   public static final double DEFAULT_PORTRAIT_BLUR = 0;

--- a/src/main/java/net/rptools/tokentool/AppSetup.java
+++ b/src/main/java/net/rptools/tokentool/AppSetup.java
@@ -135,14 +135,16 @@ public class AppSetup {
     int overlaysInstalled = 0;
 
     // Get list of overlays from src/main/resources
-    Set<String> moduleResourceSet = ModuleLayer.boot().configuration().modules()
-        .stream()
-        .map(ResolvedModule::reference)
-        .filter(it -> it.descriptor().name().equals("net.rptools.tokentool"))
-        .findFirst().get().open()
-        .list()
-        .filter(it -> it.startsWith(DEFAULT_OVERLAYS) && !it.endsWith("/"))
-        .collect(Collectors.toSet());
+    Set<String> moduleResourceSet =
+        ModuleLayer.boot().configuration().modules().stream()
+            .map(ResolvedModule::reference)
+            .filter(it -> it.descriptor().name().equals("net.rptools.tokentool"))
+            .findFirst()
+            .get()
+            .open()
+            .list()
+            .filter(it -> it.startsWith(DEFAULT_OVERLAYS) && !it.endsWith("/"))
+            .collect(Collectors.toSet());
 
     for (String resourcePath : moduleResourceSet) {
       String resourceName = resourcePath.substring(DEFAULT_OVERLAYS.length());
@@ -214,11 +216,11 @@ public class AppSetup {
       return false;
     }
 
-    String[] versions = version.indexOf(".") > 0 ? version.split("\\.") : new String[]{version};
+    String[] versions = version.indexOf(".") > 0 ? version.split("\\.") : new String[] {version};
     String[] installedVersions =
         installedVersion.indexOf(".") > 0
             ? installedVersion.split("\\.")
-            : new String[]{installedVersion};
+            : new String[] {installedVersion};
 
     int i = 0;
     try {

--- a/src/main/java/net/rptools/tokentool/controller/PdfViewer_Controller.java
+++ b/src/main/java/net/rptools/tokentool/controller/PdfViewer_Controller.java
@@ -359,7 +359,8 @@ public class PdfViewer_Controller implements Initializable {
               extractAllImagesLabel.setVisible(true);
 
               for (int page = 0; page < pageCount; page++) {
-                pdfModel.extractAllImagesFromPage(selectedDirectory.getPath(), imageFormat, page, imageMinDimension);
+                pdfModel.extractAllImagesFromPage(
+                    selectedDirectory.getPath(), imageFormat, page, imageMinDimension);
                 updateProgress(page, pageCount);
                 updateMessage("Extracting page " + page + " of " + pageCount);
 

--- a/src/main/java/net/rptools/tokentool/controller/TokenTool_Controller.java
+++ b/src/main/java/net/rptools/tokentool/controller/TokenTool_Controller.java
@@ -38,7 +38,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-
 import javafx.animation.FadeTransition;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
@@ -197,7 +196,8 @@ public class TokenTool_Controller {
   private NavigableSet<Integer> overlaySpinnerSteps =
       new TreeSet<>(
           Arrays.asList(
-              50, 64, 100, 128, 150, 200, 256, 300, 400, 500, 512, 600, 700, 750, 800, 900, 1000, 1024));
+              50, 64, 100, 128, 150, 200, 256, 300, 400, 500, 512, 600, 700, 750, 800, 900, 1000,
+              1024));
 
   private PdfViewer pdfViewer;
 
@@ -829,8 +829,7 @@ public class TokenTool_Controller {
           x++;
           y++;
         }
-        default -> {
-        }
+        default -> {}
       }
 
       getCurrentLayer().setTranslateX(x);
@@ -1251,13 +1250,14 @@ public class TokenTool_Controller {
     FileChooser fileChooser = new FileChooser();
     log.info("***** Saving Token as a {}", fileExtension);
 
-    File tokenFile = fileSaveUtil.getFileName(
-      false,
-      useFileNumberingCheckbox.isSelected(),
-      fileNameTextField.getText(),
-      getFileSaveFormatChoiceboxSelection(),
-      fileNameSuffixTextField,
-      true);
+    File tokenFile =
+        fileSaveUtil.getFileName(
+            false,
+            useFileNumberingCheckbox.isSelected(),
+            fileNameTextField.getText(),
+            getFileSaveFormatChoiceboxSelection(),
+            fileNameSuffixTextField,
+            true);
     fileChooser.setInitialFileName(tokenFile.getName());
     if (tokenFile.getParentFile() != null && tokenFile.getParentFile().isDirectory()) {
       fileChooser.setInitialDirectory(tokenFile.getParentFile());
@@ -1266,12 +1266,11 @@ public class TokenTool_Controller {
     fileChooser.getExtensionFilters().addAll(AppConstants.IMAGE_EXTENSION_FILTER);
     fileChooser.setTitle(I18N.getString("TokenTool.save.filechooser.title"));
 
-    fileChooser.setSelectedExtensionFilter(AppConstants.IMAGE_EXTENSION_FILTER
-        .stream()
-        .filter(it -> it.getExtensions().contains("*." + fileExtension))
-        .findFirst()
-        .orElse(AppConstants.DEFAULT_EXTENSION_FILTER)
-    );
+    fileChooser.setSelectedExtensionFilter(
+        AppConstants.IMAGE_EXTENSION_FILTER.stream()
+            .filter(it -> it.getExtensions().contains("*." + fileExtension))
+            .findFirst()
+            .orElse(AppConstants.DEFAULT_EXTENSION_FILTER));
 
     File tokenSaved = fileChooser.showSaveDialog(saveOptionsPane.getScene().getWindow());
 
@@ -1321,7 +1320,8 @@ public class TokenTool_Controller {
     } catch (IOException e) {
       log.error("Unable to write token to file: " + tokenFile.getAbsolutePath(), e);
     } catch (IndexOutOfBoundsException e) {
-      log.error("Image width/height out of bounds: " + getOverlayWidth() + " x " + getOverlayHeight(), e);
+      log.error(
+          "Image width/height out of bounds: " + getOverlayWidth() + " x " + getOverlayHeight(), e);
     }
 
     return false;

--- a/src/main/java/net/rptools/tokentool/util/ExtractImagesFromPDF.java
+++ b/src/main/java/net/rptools/tokentool/util/ExtractImagesFromPDF.java
@@ -149,7 +149,8 @@ public final class ExtractImagesFromPDF {
         if (!imageTracker.contains(xObject.getCOSObject())) {
           imageTracker.add(xObject.getCOSObject());
 
-          String name = pdfName + " - pg " + (currentPageNumber + 1) + " - img " + imageTracker.size();
+          String name =
+              pdfName + " - pg " + (currentPageNumber + 1) + " - img " + imageTracker.size();
 
           log.debug("Extracting image... " + name);
 

--- a/src/main/java/net/rptools/tokentool/util/FileSaveUtil.java
+++ b/src/main/java/net/rptools/tokentool/util/FileSaveUtil.java
@@ -151,8 +151,13 @@ public class FileSaveUtil {
     return new File(System.getProperty("java.io.tmpdir"), tempFileName);
   }
 
-  public File getFileName(boolean asToken, boolean useNumbering, String tempFileName, String imageExtension,
-      TextField fileNameSuffix, boolean advanceFileNameSuffix) {
+  public File getFileName(
+      boolean asToken,
+      boolean useNumbering,
+      String tempFileName,
+      String imageExtension,
+      TextField fileNameSuffix,
+      boolean advanceFileNameSuffix) {
 
     imageExtension = "." + imageExtension;
 


### PR DESCRIPTION
Fixes #449

Adding log4j-core as an implementation dependency makes the version match (2.19 instead of 2.17) and allows log4j to properly load.

I also noticed spotless has been disabled for a long time now, but it doesn't look like that needs to be the case. So I reenabled it, hence the handful of formatting changes.

Also updated the `verify-build` workflow to use `actions/cache@v4` as the old version is not fully compatible with the new cache service (see [the recommendation](https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/README.md#%EF%B8%8F-important-changes) on that project).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/TokenTool/450)
<!-- Reviewable:end -->
