### PR TITLE
Improve image preview performance on Linux

### DIFF
--- a/src/main/java/net/rptools/tokentool/controller/TokenTool_Controller.java
+++ b/src/main/java/net/rptools/tokentool/controller/TokenTool_Controller.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1250,17 +1251,29 @@ public class TokenTool_Controller {
   }
 
   public void updateTokenPreviewImageView() {
-    tokenImageView.setImage(
-        ImageUtil.composePreview(
-            compositeTokenPane,
-            backgroundImageView,
-            backgroundColorPicker.getValue(),
-            portraitImageView,
-            maskImageView,
-            overlayImageView,
-            overlayUseAsBaseCheckbox.isSelected(),
-            clipPortraitCheckbox.isSelected()));
-    tokenImageView.setPreserveRatio(true);
+    compositeTokenPane.layout();
+
+    boolean clip =
+        clipPortraitCheckbox.isSelected()
+            && maskImageView.getFitWidth() > 0
+            && maskImageView.getFitHeight() > 0;
+    CompletableFuture<? extends Image> future =
+        clip
+            ? ImageUtil.Async.composeClippedPreview(
+                backgroundImageView,
+                backgroundColorPicker.getValue(),
+                portraitImageView,
+                maskImageView,
+                overlayImageView,
+                overlayUseAsBaseCheckbox.isSelected())
+            : ImageUtil.Async.composeUnclippedPreview(compositeTokenPane);
+    future
+        .thenCompose(i -> ImageUtil.Async.autoCrop(i))
+        .thenAccept(
+            cropped -> {
+              tokenImageView.setImage(cropped);
+              tokenImageView.setPreserveRatio(true);
+            });
   }
 
   private void saveToken() {

--- a/src/main/java/net/rptools/tokentool/controller/TokenTool_Controller.java
+++ b/src/main/java/net/rptools/tokentool/controller/TokenTool_Controller.java
@@ -157,7 +157,6 @@ public class TokenTool_Controller {
   @FXML private StackPane imagesStackPane;
   @FXML private ImageView backgroundImageView; // The background image layer
   @FXML private ImageView portraitImageView; // The bottom "Portrait" layer
-  @FXML private ImageView maskImageView; // The mask layer used to crop the Portrait layer
   @FXML private ImageView overlayImageView; // The overlay layer to apply on top of everything
   @FXML private ImageView tokenImageView; // The final token image created
   @FXML private CheckBox useFileNumberingCheckbox;
@@ -191,6 +190,13 @@ public class TokenTool_Controller {
   @FXML private RadioMenuItem portraitMenuItem;
   @FXML private RadioMenuItem overlayMenuItem;
   private FileSaveUtil fileSaveUtil = new FileSaveUtil();
+
+  /**
+   * The mask layer used to crop the Portrait layer.
+   *
+   * <p>This is not part of the main scene, but is used when compositing result images.
+   */
+  private ImageView maskImageView;
 
   // A custom set of Width/Height sizes to use for Overlays
   private NavigableSet<Integer> overlaySpinnerSteps =
@@ -252,8 +258,6 @@ public class TokenTool_Controller {
         : "fx:id=\"backgroundImageView\" was not injected: check your FXML file 'TokenTool.fxml'.";
     assert portraitImageView != null
         : "fx:id=\"portraitImageView\" was not injected: check your FXML file 'TokenTool.fxml'.";
-    assert maskImageView != null
-        : "fx:id=\"maskImageView\" was not injected: check your FXML file 'TokenTool.fxml'.";
     assert overlayImageView != null
         : "fx:id=\"overlayImageView\" was not injected: check your FXML file 'TokenTool.fxml'.";
     assert tokenImageView != null
@@ -324,6 +328,20 @@ public class TokenTool_Controller {
         : "fx:id=\"portraitMenuItem\" was not injected: check your FXML file 'TokenTool.fxml'.";
     assert overlayMenuItem != null
         : "fx:id=\"overlayMenuItem\" was not injected: check your FXML file 'TokenTool.fxml'.";
+
+    var defaultImageUrl =
+        getClass().getResource("/net/rptools/tokentool/image/gear-chrome-mask.png");
+    maskImageView =
+        defaultImageUrl == null ? new ImageView() : new ImageView(defaultImageUrl.toExternalForm());
+    maskImageView.setVisible(true);
+    maskImageView.setId("maskImageView");
+    maskImageView.setFitWidth(256);
+    maskImageView.setFitHeight(256);
+    maskImageView.setLayoutX(1);
+    maskImageView.setLayoutY(1);
+    maskImageView.setMouseTransparent(true);
+    maskImageView.setPickOnBounds(true);
+    maskImageView.setPreserveRatio(true);
 
     // We're getting the defaults set by the FXML before updating them with the saved preferences...
     AppConstants.DEFAULT_MASK_IMAGE = maskImageView.getImage();

--- a/src/main/java/net/rptools/tokentool/util/ImageUtil.java
+++ b/src/main/java/net/rptools/tokentool/util/ImageUtil.java
@@ -24,9 +24,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -34,7 +36,6 @@ import javafx.scene.image.PixelReader;
 import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.image.WritablePixelFormat;
-import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javax.imageio.ImageIO;
@@ -249,142 +250,9 @@ public class ImageUtil {
     return outputImage;
   }
 
-  /*
-   * Crop image to smallest width/height based on transparency
-   */
-  private static Image autoCropImage(Image imageSource) {
-    return autoCropImage(imageSource, Color.TRANSPARENT, null);
-  }
-
   public static Image autoCropImage(
       Image imageSource, Color backgroundColor, Image backgroundImage) {
-    ImageView croppedImageView = new ImageView(imageSource);
-    PixelReader pixelReader = imageSource.getPixelReader();
-
-    int imageWidth = (int) imageSource.getWidth();
-    int imageHeight = (int) imageSource.getHeight();
-    int minX = imageWidth, minY = imageHeight, maxX = 0, maxY = 0;
-
-    // Find the first and last pixels that are not transparent to create a bounding viewport
-    for (int readY = 0; readY < imageHeight; readY++) {
-      for (int readX = 0; readX < imageWidth; readX++) {
-        Color pixelColor = pixelReader.getColor(readX, readY);
-
-        if (!pixelColor.equals(Color.TRANSPARENT)) {
-          if (readX < minX) {
-            minX = readX;
-          }
-          if (readX > maxX) {
-            maxX = readX;
-          }
-
-          if (readY < minY) {
-            minY = readY;
-          }
-          if (readY > maxY) {
-            maxY = readY;
-          }
-        }
-      }
-    }
-
-    if (maxX - minX <= 0 || maxY - minY <= 0) {
-      return new WritableImage(1, 1);
-    }
-
-    // Create a viewport to clip the image using snapshot
-    Rectangle2D viewPort = new Rectangle2D(minX, minY, maxX - minX, maxY - minY);
-    SnapshotParameters parameter = new SnapshotParameters();
-    parameter.setViewport(viewPort);
-    parameter.setFill(backgroundColor);
-
-    if (backgroundImage != null) {
-      return new Group(new ImageView(backgroundImage), croppedImageView).snapshot(parameter, null);
-    } else {
-      return croppedImageView.snapshot(parameter, null);
-    }
-  }
-
-  public static Image composePreview(
-      StackPane compositeTokenPane,
-      ImageView backgroundImageView,
-      Color bgColor,
-      ImageView portraitImageView,
-      ImageView maskImageView,
-      ImageView overlayImageView,
-      boolean useAsBase,
-      boolean clipImage) {
-
-    // Process layout as maskImage may have changed size if the overlay was changed
-    compositeTokenPane.layout();
-    SnapshotParameters parameter = new SnapshotParameters();
-    Image finalImage;
-    Group blend;
-
-    // check if there is a mask image
-    if (maskImageView.getFitWidth() <= 0 || maskImageView.getFitHeight() <= 0) {
-      clipImage = false;
-    }
-
-    if (clipImage) {
-      // We need to clip the portrait image first then blend the overlay image over it
-      // We will first get a snapshot of the portrait equal to the mask overlay image width/height
-      // We will then get a snapshot of the background image, if any.
-      double x, y, width, height;
-
-      x = overlayImageView.getParent().getLayoutX();
-      y = overlayImageView.getParent().getLayoutY();
-      width = overlayImageView.getFitWidth();
-      height = overlayImageView.getFitHeight();
-
-      Rectangle2D viewPort = new Rectangle2D(x, y, width, height);
-      Rectangle2D maskViewPort = new Rectangle2D(1, 1, width, height);
-      WritableImage newBackgroundImage = new WritableImage((int) width, (int) height);
-      WritableImage newImage = new WritableImage((int) width, (int) height);
-      WritableImage newMaskImage = new WritableImage((int) width, (int) height);
-
-      ImageView newBackgroundImageView = new ImageView();
-      ImageView overlayCopyImageView = new ImageView();
-      ImageView clippedImageView = new ImageView();
-
-      parameter.setViewport(viewPort);
-      parameter.setFill(bgColor);
-      backgroundImageView.snapshot(parameter, newBackgroundImage);
-
-      parameter.setFill(Color.TRANSPARENT);
-      portraitImageView.snapshot(parameter, newImage);
-
-      parameter.setViewport(maskViewPort);
-      maskImageView.snapshot(parameter, newMaskImage);
-
-      clippedImageView.setFitWidth(width);
-      clippedImageView.setFitHeight(height);
-      clippedImageView.setImage(clipImageWithMask(newImage, newMaskImage));
-      newBackgroundImageView.setImage(clipImageWithMask(newBackgroundImage, newMaskImage));
-
-      // Our masked portrait image is now stored in clippedImageView, lets now blend the overlay
-      // image over it
-      // We'll create a temporary group to hold our temporary ImageViews's and blend them and take a
-      // snapshot
-      overlayCopyImageView.setImage(overlayImageView.getImage());
-      overlayCopyImageView.setFitWidth(overlayImageView.getFitWidth());
-      overlayCopyImageView.setFitHeight(overlayImageView.getFitHeight());
-      overlayCopyImageView.setOpacity(overlayImageView.getOpacity());
-
-      if (useAsBase) {
-        blend = new Group(newBackgroundImageView, overlayCopyImageView, clippedImageView);
-      } else {
-        blend = new Group(newBackgroundImageView, clippedImageView, overlayCopyImageView);
-      }
-
-      // Last, we'll clean up any excess transparent edges by cropping it
-      finalImage = autoCropImage(blend.snapshot(parameter, null));
-    } else {
-      parameter.setFill(Color.TRANSPARENT);
-      finalImage = autoCropImage(compositeTokenPane.snapshot(parameter, null));
-    }
-
-    return finalImage;
+    return Async.autoCrop(imageSource, backgroundColor, backgroundImage, false).join();
   }
 
   /*
@@ -463,5 +331,184 @@ public class ImageUtil {
         new ExtensionFilter("BMP" + I18N.getString("imageUtil.filetype.label.files"), "*.bmp"));
 
     return extensionFilters;
+  }
+
+  public static final class Async {
+    public static CompletableFuture<WritableImage> snapshot(
+        Node node, SnapshotParameters parameters, WritableImage image) {
+      CompletableFuture<WritableImage> future = new CompletableFuture<>();
+      node.snapshot(
+          result -> {
+            future.complete(result.getImage());
+            return null;
+          },
+          parameters,
+          image);
+      return future;
+    }
+
+    public static CompletableFuture<WritableImage> autoCrop(Image imageSource) {
+      return autoCrop(imageSource, Color.TRANSPARENT, null, true);
+    }
+
+    private static CompletableFuture<WritableImage> autoCrop(
+        Image imageSource, Color backgroundColor, Image backgroundImage, boolean async) {
+      PixelReader pixelReader = imageSource.getPixelReader();
+
+      int imageWidth = (int) imageSource.getWidth();
+      int imageHeight = (int) imageSource.getHeight();
+      int minX = imageWidth, minY = imageHeight, maxX = 0, maxY = 0;
+
+      // Find the first and last pixels that are not transparent to create a bounding viewport
+      for (int readY = 0; readY < imageHeight; readY++) {
+        for (int readX = 0; readX < imageWidth; readX++) {
+          Color pixelColor = pixelReader.getColor(readX, readY);
+
+          if (!pixelColor.equals(Color.TRANSPARENT)) {
+            if (readX < minX) {
+              minX = readX;
+            }
+            if (readX > maxX) {
+              maxX = readX;
+            }
+
+            if (readY < minY) {
+              minY = readY;
+            }
+            if (readY > maxY) {
+              maxY = readY;
+            }
+          }
+        }
+      }
+
+      if (maxX - minX <= 0 || maxY - minY <= 0) {
+        return CompletableFuture.completedFuture(new WritableImage(1, 1));
+      }
+
+      // Create a viewport to clip the image using snapshot
+      Rectangle2D viewPort = new Rectangle2D(minX, minY, maxX - minX, maxY - minY);
+      SnapshotParameters parameter = new SnapshotParameters();
+      parameter.setViewport(viewPort);
+      parameter.setFill(backgroundColor);
+
+      Node node = new ImageView(imageSource);
+      if (backgroundImage != null) {
+        node = new Group(new ImageView(backgroundImage), node);
+      }
+
+      if (async) {
+        return snapshot(node, parameter, null);
+      } else {
+        return CompletableFuture.completedFuture(node.snapshot(parameter, null));
+      }
+    }
+
+    public static CompletableFuture<WritableImage> composeUnclippedPreview(Node node) {
+      SnapshotParameters parameter = new SnapshotParameters();
+      parameter.setFill(Color.TRANSPARENT);
+      return ImageUtil.Async.snapshot(node, parameter, null);
+    }
+
+    public static CompletableFuture<WritableImage> composeClippedPreview(
+        ImageView backgroundImageView,
+        Color bgColor,
+        ImageView portraitImageView,
+        ImageView maskImageView,
+        ImageView overlayImageView,
+        boolean useAsBase) {
+      // We need to clip the portrait image first then blend the overlay image over it
+      // We will first get a snapshot of the portrait equal to the mask overlay image width/height
+      // We will then get a snapshot of the background image, if any.
+      final var viewport =
+          new Rectangle2D(
+              overlayImageView.getParent().getLayoutX(),
+              overlayImageView.getParent().getLayoutY(),
+              overlayImageView.getFitWidth(),
+              overlayImageView.getFitHeight());
+      final var maskViewport = new Rectangle2D(1, 1, viewport.getWidth(), viewport.getHeight());
+
+      final CompletableFuture<? extends Image> backgroundFuture;
+      {
+        SnapshotParameters backgroundParameters = new SnapshotParameters();
+        backgroundParameters.setViewport(viewport);
+        backgroundParameters.setFill(bgColor);
+        backgroundFuture =
+            snapshot(
+                backgroundImageView,
+                backgroundParameters,
+                null // new WritableImage((int) viewport.getWidth(), (int) viewport.getHeight())
+                );
+      }
+
+      final CompletableFuture<? extends Image> portraitFuture;
+      {
+        SnapshotParameters portraitParameters = new SnapshotParameters();
+        portraitParameters.setViewport(viewport);
+        portraitParameters.setFill(Color.TRANSPARENT);
+        portraitFuture =
+            snapshot(
+                portraitImageView,
+                portraitParameters,
+                new WritableImage((int) viewport.getWidth(), (int) viewport.getHeight()));
+      }
+
+      final CompletableFuture<? extends Image> maskFuture;
+      {
+        // TODO Surely this is just a scaled version of the original mask image. Can we not somehow
+        //  use that directly?
+        SnapshotParameters maskParameters = new SnapshotParameters();
+        maskParameters.setViewport(maskViewport);
+        maskParameters.setFill(Color.TRANSPARENT);
+        maskFuture =
+            snapshot(
+                maskImageView,
+                maskParameters,
+                new WritableImage((int) viewport.getWidth(), (int) viewport.getHeight()));
+      }
+
+      return CompletableFuture.allOf(backgroundFuture, portraitFuture, maskFuture)
+          .thenCompose(
+              ignored -> {
+                var newBackgroundImage = backgroundFuture.join();
+                var newImage = portraitFuture.join();
+                var newMaskImage = maskFuture.join();
+
+                ImageView clippedImageView = new ImageView();
+                clippedImageView.setFitWidth(viewport.getWidth());
+                clippedImageView.setFitHeight(viewport.getHeight());
+                clippedImageView.setImage(clipImageWithMask(newImage, newMaskImage));
+
+                ImageView newBackgroundImageView = new ImageView();
+                newBackgroundImageView.setImage(
+                    clipImageWithMask(newBackgroundImage, newMaskImage));
+
+                // Our masked portrait image is now stored in clippedImageView, lets now blend the
+                // overlay
+                // image over it
+                // We'll create a temporary group to hold our temporary ImageViews's and blend them
+                // and take a
+                // snapshot
+                ImageView overlayCopyImageView = new ImageView();
+                overlayCopyImageView.setImage(overlayImageView.getImage());
+                overlayCopyImageView.setFitWidth(overlayImageView.getFitWidth());
+                overlayCopyImageView.setFitHeight(overlayImageView.getFitHeight());
+                overlayCopyImageView.setOpacity(overlayImageView.getOpacity());
+
+                Group blend;
+                if (useAsBase) {
+                  blend = new Group(newBackgroundImageView, overlayCopyImageView, clippedImageView);
+                } else {
+                  blend = new Group(newBackgroundImageView, clippedImageView, overlayCopyImageView);
+                }
+
+                // Last, we'll clean up any excess transparent edges by cropping it
+                SnapshotParameters groupParameters = new SnapshotParameters();
+                groupParameters.setViewport(
+                    new Rectangle2D(1, 1, viewport.getWidth(), viewport.getHeight()));
+                groupParameters.setFill(Color.TRANSPARENT);
+                return snapshot(blend, groupParameters, null);
+              });
+    }
   }
 }

--- a/src/main/java/net/rptools/tokentool/util/ImageUtil.java
+++ b/src/main/java/net/rptools/tokentool/util/ImageUtil.java
@@ -16,7 +16,6 @@ package net.rptools.tokentool.util;
 
 import com.twelvemonkeys.imageio.plugins.psd.PSDImageReader;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -138,7 +137,7 @@ public class ImageUtil {
 
       try (ImageInputStream is = ImageIO.createImageInputStream(file)) {
         if (is == null || is.length() == 0) {
-          log.info("Image from file " + file.getAbsolutePath() + " is null");
+          log.info("Image from file {} is null", file.getAbsolutePath());
         }
 
         Iterator<ImageReader> iterator = ImageIO.getImageReaders(is);
@@ -178,7 +177,7 @@ public class ImageUtil {
           thumb = resizeCanvas(SwingFXUtils.toFXImage(thumbBI, null), width, height, x, y);
         }
       } catch (Exception e) {
-        log.error("Processing: " + file.getAbsolutePath(), e);
+        log.error("Processing: {}", file.getAbsolutePath(), e);
       } finally {
         // Dispose reader in finally block to avoid memory leaks
         if (reader != null) {
@@ -223,18 +222,6 @@ public class ImageUtil {
         offsetX, offsetY, sourceWidth, sourceHeight, format, buffer, 0, sourceWidth);
 
     return outputImage;
-  }
-
-  /*
-   * Resize the overall image width/height scaled to the target width/height
-   */
-  public static Image scaleImage(
-      Image source, double targetWidth, double targetHeight, boolean preserveRatio) {
-    ImageView imageView = new ImageView(source);
-    imageView.setPreserveRatio(preserveRatio);
-    imageView.setFitWidth(targetWidth);
-    imageView.setFitHeight(targetHeight);
-    return imageView.snapshot(null, null);
   }
 
   /*
@@ -402,14 +389,6 @@ public class ImageUtil {
     return finalImage;
   }
 
-  public static double getScaleXRatio(ImageView imageView) {
-    return imageView.getBoundsInParent().getWidth() / imageView.getImage().getWidth();
-  }
-
-  public static double getScaleYRatio(ImageView imageView) {
-    return imageView.getBoundsInParent().getHeight() / imageView.getImage().getHeight();
-  }
-
   /*
    * This is for Legacy support but can cause magenta bleed on edges if there is transparency overlap. The preferred overlay storage is now PhotoShop PSD format with layer 1 containing the mask and
    * layer 2 containing the image
@@ -461,17 +440,6 @@ public class ImageUtil {
       return FilenameUtils.getExtension(imageFile.getName()).toUpperCase()
           + I18N.getString("imageUtil.filetype.label.extension");
     }
-  }
-
-  public static byte[] imageToBytes(BufferedImage image) throws IOException {
-    return imageToBytes(image, "png");
-  }
-
-  public static byte[] imageToBytes(BufferedImage image, String format) throws IOException {
-    ByteArrayOutputStream outStream = new ByteArrayOutputStream(10000);
-    ImageIO.write(image, format, outStream);
-
-    return outStream.toByteArray();
   }
 
   public static List<ExtensionFilter> GET_EXTENSION_FILTERS() {

--- a/src/main/java/net/rptools/tokentool/util/ImageUtil.java
+++ b/src/main/java/net/rptools/tokentool/util/ImageUtil.java
@@ -332,10 +332,10 @@ public class ImageUtil {
       // We will then get a snapshot of the background image, if any.
       double x, y, width, height;
 
-      x = maskImageView.getParent().getLayoutX();
-      y = maskImageView.getParent().getLayoutY();
-      width = maskImageView.getFitWidth();
-      height = maskImageView.getFitHeight();
+      x = overlayImageView.getParent().getLayoutX();
+      y = overlayImageView.getParent().getLayoutY();
+      width = overlayImageView.getFitWidth();
+      height = overlayImageView.getFitHeight();
 
       Rectangle2D viewPort = new Rectangle2D(x, y, width, height);
       Rectangle2D maskViewPort = new Rectangle2D(1, 1, width, height);
@@ -355,9 +355,7 @@ public class ImageUtil {
       portraitImageView.snapshot(parameter, newImage);
 
       parameter.setViewport(maskViewPort);
-      maskImageView.setVisible(true);
       maskImageView.snapshot(parameter, newMaskImage);
-      maskImageView.setVisible(false);
 
       clippedImageView.setFitWidth(width);
       clippedImageView.setFitHeight(height);

--- a/src/main/resources/net/rptools/tokentool/view/TokenTool.fxml
+++ b/src/main/resources/net/rptools/tokentool/view/TokenTool.fxml
@@ -117,11 +117,6 @@
 										</ScrollPane>
 										<Group fx:id="compositeGroup">
 											<children>
-												<ImageView fx:id="maskImageView" fitHeight="256.0" fitWidth="256.0" layoutX="1.0" layoutY="1.0" mouseTransparent="true" pickOnBounds="true" preserveRatio="true" visible="false">
-													<image>
-														<Image url="@../image/gear-chrome-mask.png" />
-													</image>
-												</ImageView>
 												<ImageView fx:id="overlayImageView" fitHeight="256.0" fitWidth="256.0" layoutX="1.0" layoutY="1.0" mouseTransparent="true" pickOnBounds="true" preserveRatio="true">
 													<image>
 														<Image url="@../image/gear-chrome-no-mask.png" />


### PR DESCRIPTION
Closes #447

The core of this change is switching from [`Node#snapshot(SnapshotParameters, WritableImage)`](https://openjfx.io/javadoc/22/javafx.graphics/javafx/scene/Node.html#snapshot(javafx.scene.SnapshotParameters,javafx.scene.image.WritableImage)) to [`Node#snapshot(Callback, SnapshotParameters, WritableImage)`](https://openjfx.io/javadoc/22/javafx.graphics/javafx/scene/Node.html#snapshot(javafx.util.Callback,javafx.scene.SnapshotParameters,javafx.scene.image.WritableImage)) when rendering the preview image. This is represented by the new `ImageUtil.Async.snapshot()` which wraps that method to in a `CompletableFuture<>` so that callback aren't required.

Operations that depend on snapshots had to be rewritten to account for the asynchony:
1. `ImageUtil.autoCropImage()` is mostly replaced with `ImageUtil.Async.autoCrop()`.
2. `ImageUtil.composePreview()` is replaced by `ImageUtil.Async.composeClippedPreview()` and `ImageUtil.Async.composeUnclippedPreview()`, depending on the current clip settings.

The only problem with the above changes is the `maskImageView`. It needs to be made visible in order to snapshot it, only to be hidden again right away. But with asynchronous snapshots, we can't guarantee that it will be hidden again in time for the next frame, which results in it flickering. To fix that, I've removed `maskImageView` from the scene since it is never meant to be rendered there, though it remains part of `TokenTool_Controller`. Now it is only incorporated it into a `Group` when rendering the preview. This lets us leave it marked as visible since it will never actually be on screen.

Finally, I've removed some of the unused methods in `ImageUtil`:
- `scaleImage()`
- `getScaleXRatio()`
- `getScaleYRatio()`
- `imageToBytes()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/TokenTool/453)
<!-- Reviewable:end -->
